### PR TITLE
Update SPPatchify-Download-CU.csv

### DIFF
--- a/SPPatchify-Download-CU.csv
+++ b/SPPatchify-Download-CU.csv
@@ -1,4 +1,6 @@
 Year,Month,Product,URL
+2018,9,SP16,https://download.microsoft.com/download/B/A/0/BA07CD33-9A5D-4C06-ADF3-BF604D6B9716/sts2016-kb4092459-fullfile-x64-glb.exe
+2018,9,SP16,https://download.microsoft.com/download/5/E/A/5EADC4E3-A66B-4C2F-96E5-CA744ABE945E/wssloc2016-kb4022231-fullfile-x64-glb.exe
 2018,8,SP16,https://download.microsoft.com/download/4/D/5/4D51E797-35F0-4F8E-9EAF-9B6325BA45FD/sts2016-kb4032256-fullfile-x64-glb.exe
 2018,8,SP16,https://download.microsoft.com/download/5/E/A/5EADC4E3-A66B-4C2F-96E5-CA744ABE945E/wssloc2016-kb4022231-fullfile-x64-glb.exe
 2018,7,SP16,https://download.microsoft.com/download/2/6/5/2655418E-09E8-434D-8D07-5BA36D6FABF5/sts2016-kb4022228-fullfile-x64-glb.exe
@@ -56,6 +58,9 @@ Year,Month,Product,URL
 2016,5,SP16,https://download.microsoft.com/download/7/D/A/7DA2A7E4-1903-45DA-A1AF-1DF8E79CBABB/wssloc2016-kb2920690-fullfile-x64-glb.exe
 2016,5,SP16,https://download.microsoft.com/download/1/D/2/1D2C38A0-4AE7-47B3-9365-F603CBF1F154/sts2016-kb3115088-fullfile-x64-glb.exe
 2016,4,SP16,https://download.microsoft.com/download/8/D/5/8D589BA9-3EA3-4AF8-A5D6-7BC4DE028531/sts2016-kb2920721-fullfile-x64-glb.exe
+2018,9,SP15,https://download.microsoft.com/download/6/1/6/616BD018-CD14-4CE1-908C-B5EDE2446D30/ubersrv2013-kb4092476-fullfile-x64-glb.exe
+2018,9,SP15,https://download.microsoft.com/download/6/1/6/616BD018-CD14-4CE1-908C-B5EDE2446D30/ubersrv_1.cab
+2018,9,SP15,https://download.microsoft.com/download/6/1/6/616BD018-CD14-4CE1-908C-B5EDE2446D30/ubersrv_2.cab
 2018,8,SP15,https://download.microsoft.com/download/5/6/6/5664E5D9-B6A4-4762-B45F-44492E3C3628/ubersrv2013-kb4032247-fullfile-x64-glb.exe
 2018,8,SP15,https://download.microsoft.com/download/5/6/6/5664E5D9-B6A4-4762-B45F-44492E3C3628/ubersrv_1.cab
 2018,8,SP15,https://download.microsoft.com/download/5/6/6/5664E5D9-B6A4-4762-B45F-44492E3C3628/ubersrv_2.cab
@@ -111,6 +116,9 @@ Year,Month,Product,URL
 2017,1,SP15,https://download.microsoft.com/download/A/E/B/AEBBF76F-823F-4A0A-A398-183641466737/ubersrv2013-kb3141481-fullfile-x64-glb.exe
 2017,1,SP15,https://download.microsoft.com/download/A/E/B/AEBBF76F-823F-4A0A-A398-183641466737/ubersrv_1.cab
 2017,1,SP15,https://download.microsoft.com/download/A/E/B/AEBBF76F-823F-4A0A-A398-183641466737/ubersrv_2.cab
+2018,9,PROJ15,https://download.microsoft.com/download/D/8/0/D80D855C-2749-4A5B-B0D2-EE25C8AB6D68/ubersrvprj2013-kb4092475-fullfile-x64-glb.exe
+2018,9,PROJ15,https://download.microsoft.com/download/D/8/0/D80D855C-2749-4A5B-B0D2-EE25C8AB6D68/ubersrvprj_1.cab
+2018,9,PROJ15,https://download.microsoft.com/download/D/8/0/D80D855C-2749-4A5B-B0D2-EE25C8AB6D68/ubersrvprj_2.cab
 2018,8,PROJ15,https://download.microsoft.com/download/9/4/F/94FFE1A7-3F90-4B00-A686-FEEF7AD8BDE4/ubersrvprj2013-kb4032245-fullfile-x64-glb.exe
 2018,8,PROJ15,https://download.microsoft.com/download/9/4/F/94FFE1A7-3F90-4B00-A686-FEEF7AD8BDE4/ubersrvprj_1.cab
 2018,8,PROJ15,https://download.microsoft.com/download/9/4/F/94FFE1A7-3F90-4B00-A686-FEEF7AD8BDE4/ubersrvprj_2.cab


### PR DESCRIPTION
Added September '18 Patches for SharePoint Server 2013, Project Server 2013, SharePoint Server 2016 (used the wssloc from August, because there was no wssloc patch in September)