### PR TITLE
Project13 detection update

### DIFF
--- a/SPPatchify.ps1
+++ b/SPPatchify.ps1
@@ -1179,7 +1179,7 @@ function PatchMenu() {
         $farm = Get-SPFarm -ErrorAction SilentlyContinue
         if ($farm) {
             $ver = $farm.BuildVersion.Major
-            $sppl = (Get-SPProduct -Local) |Where-Object {$_.ProductName -like "*Microsoft Project*"}
+            $sppl = (Get-SPProduct -Local) |Where-Object {($_.ProductName -like "*Microsoft Project*" -or $_.ProductName -like "*Microsoft® Project*")}
             if ($sppl) {
                 if ($ver -ne 16) {
                     $sku = "PROJ"


### PR DESCRIPTION
Tested it on a Project 2013 farm. Get-SPProduct -Local returns "Microsoft® Project Server 2013". The ® icon is not included in the like statement "*Microsoft Project*", meaning it will download SharePoint files in stead of Project files.
Propose to include -or statement with -like "*Microsoft® Project*".