### PR TITLE
Update SPPatchify.ps1

### DIFF
--- a/SPPatchify.ps1
+++ b/SPPatchify.ps1
@@ -641,7 +641,7 @@ function ChangeServices($state) {
         $action = "STOP"
         $sb = {
             Start-Process 'iisreset.exe' -ArgumentList '/stop' -Wait -PassThru -NoNewWindow | Out-Null
-            @("IISADMIN", "W3SVC", "SPAdminV4", "SPTimerV4", "SQLBrowser", "Schedule", "SPInsights", "DocAve 6 Agent Service") | ForEach-Object {
+            @("IISADMIN", "SPAdminV4", "SPTimerV4", "SQLBrowser", "Schedule", "SPInsights", "DocAve 6 Agent Service") | ForEach-Object {
                 if (Get-Service $_ -ErrorAction SilentlyContinue) {
                     Set-Service -Name $_ -StartupType Disabled -ErrorAction SilentlyContinue
                     Stop-Service $_ -ErrorAction SilentlyContinue


### PR DESCRIPTION
As mentioned in #23 the disabling of the "W3SVC" service results in SharePoint 1603 errors/installation errors. After that, you can't run the PSCONFIG. You need to restart the installation with the "W3SVC" service enabled. Then everything runs fine. So I have deleted the "W3SVC" from the service -startuptype disabled.